### PR TITLE
AROSICS references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coregistration
 
-Image to image automatic co-registration processing Qgis plugin. This plugin use Arosics to perform automatic subpixel co-registration of image datasets based on an image matching approach working in the frequency domain.
+Image to image automatic co-registration processing Qgis plugin. This plugin uses AROSICS to perform automatic subpixel co-registration of image datasets based on an image matching approach working in the frequency domain.
 
 ![](docs/img/coregistration.png)
 
@@ -30,7 +30,7 @@ This global algorithm is useful when the target image requires just one shifts i
 
 This local algorithm is useful when the target image requires different pixel shifts in distances and directions. The precision of this is based on mainly in two input parameters: tie point grid resolution and matching window size. This is significantly more comprehensive and slower than global algorithm.
 
-*[1] These algorithms use Arosics software developed by Daniel Scheffler, for more info <a href="https://danschef.git-pages.gfz-potsdam.de/arosics/doc/">url</a> and <a href="https://doi.org/10.3390/rs9070676">paper</a>.
+*[1] These algorithms use AROSICS software developed by Daniel Scheffler, for more info <a href="https://danschef.git-pages.gfz-potsdam.de/arosics/doc/">url</a> and <a href="https://doi.org/10.3390/rs9070676">paper</a>.
 
 ## Installation
 
@@ -39,7 +39,7 @@ The plugin can be installed using the QGIS Plugin Manager, go into Qgis to `Plug
 The plugin will be available in the `Processing Toolbox` or you can search and open it directly from the `Statusbar`.
 
 > *Dependencies:* 
-    This plugin requires additional Python packages (`Arosics` and its depends), that are generally not part of QGIS's Python. 
+    This plugin requires additional Python packages (`AROSICS` and its dependencies), that are generally not part of QGIS's Python. 
 
 #### Windows
 For Windows users download and install the plugin using the zip `Coregistration_all_in_one_win.zip` in [releases](https://github.com/SMByC/Coregistration-Qgis-processing/releases) (alternative [link](https://drive.google.com/uc?export=download&confirm=gzst&id=1RdtkZnxR53xFpvgdssampyvSiANwiZdZ)) with all the libs and dependencies inside. This should work directly without any additional steps with a Qgis version >= 3.18 on a 64bit Windows system, if you have issues with this try with the alternative installation below.
@@ -51,7 +51,7 @@ The plugin try to install all the dependencies for you in a local folder automat
 
 ### Alternative installation
 
-If you have problems with the dependencies, the best options to solve it is use [conda](https://docs.conda.io/en/latest/miniconda.html) and install Arosics and Qgis (from the conda shell):
+If you have problems with the dependencies, the best options to solve it is use [conda](https://docs.conda.io/en/latest/miniconda.html) and install AROSICS and Qgis (from the conda shell):
 
 ```bash
 conda install -c conda-forge arosics qgis

--- a/metadata.txt
+++ b/metadata.txt
@@ -16,7 +16,7 @@ repository=https://github.com/SMByC/Coregistration-Qgis-processing
 
 changelog=
 
-tags=raster,processing,co-registration
+tags=raster,processing,co-registration,AROSICS
 
 external_deps=
 


### PR DESCRIPTION
Although I knew there is an AROSICS plugin for QGIS, it was hard to find. To make it better searchable in the QGIS Plugin Manager, this PR adds `AROSICS` to the `tag` list in metadata.txt

For consistency with https://www.mdpi.com/2072-4292/9/7/676, I also changed Arosic to uppercase (AROSICS).